### PR TITLE
no age shaming

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -4,7 +4,7 @@
   "name": "Initium New Tab",
   "description": "A new tab page that includes features such as top sites, current weather, RSS reader, calendar and much more.",
   "key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAlvDHbFeDXXQLiIFtPVMq9N/nnHKK0sNjjVcRhfnEflc6CGnjQBX2EDmUelIt3CpfZ2gkDC64xZeZ6LpNe7okIoZkj/lkD1JCr8oKCbzFoyLf//DW08jYarqyI2F2fyjJuAj+NpA3UZX+bY9m3YE8m2M7MzTxEOGZXJYeSrrO11wOdfgd2jGoE22mYc4tWhyTKgtAQQ6pLQ3jN/oXKO+ErVvmZbl7IrEK9BcwZwFy1d6K+o3blg+kHoh5EU28B/lpV6huEoFe8QhDQgmSgSTyFlgXNzHXX60GX61EscqoahPg/LQlMQ6UMcQ8KYqOEJvpUIdCrv+jn16btw+o74f0eQIDAQAB",
-  "minimum_chrome_version": "112",
+  "minimum_chrome_version": "1",
   "icons": {
     "48": "assets/48.png",
     "128": "assets/128.png"


### PR DESCRIPTION
if you fill in the blank, i can make another PR or commit like:  `chrome.runtime.onInstalled.addListener(function(installed){if(installed.reason=='install'){if 111 > Number(navigator.userAgent.match(new RegExp(chrome + '/([0-9]+)'))){alert("[Just to make sure:] Some of our features might require chrome version 111+.... _______________________") }`    ( - or rather add it precisely, when that feature is first enabled as indicated by it's button or storage change.)